### PR TITLE
Font Bug on Brochure Download Page

### DIFF
--- a/brochure.css
+++ b/brochure.css
@@ -4,7 +4,7 @@
     box-sizing: border-box;
     scroll-behavior: smooth;
 }
-body {
+body{
   font-family: "Montserrat";
 }
 


### PR DESCRIPTION
Fixing issue of font not defaulting to 'Montserrat' on brochure [responsive] page