### PR TITLE
Fixed Font Bug on Brochure Download Page [Responsive]

### DIFF
--- a/brochure.css
+++ b/brochure.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@100..900&display=swap');
+
 *{
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Fixed bug causing font family not being 'Montserrat' by setting 'import' in the css file